### PR TITLE
treewalker is substantially faster than xpath

### DIFF
--- a/DOI.js
+++ b/DOI.js
@@ -36,8 +36,6 @@
 	***** END LICENSE BLOCK *****
 */
 
-/* eslint-disable no-loop-func */
-
 // The variables items and selectArray will be filled during the first
 // as well as the second retrieveDOIs function call and therefore they
 // are defined global.
@@ -124,45 +122,42 @@ function completeDOIs(_doc) {
 }
 
 function retrieveDOIs(dois, doc) {
-	var numDois = dois.length;
+	let numDois = dois.length;
 
-	for (var DOI of dois) {
-		(function (doc, DOI) {
-			var translate = Zotero.loadTranslator("search");
-			translate.setTranslator("b28d0d42-8549-4c6d-83fc-8382874a5cb9");
+	for (const DOI of dois) {
+		const translate = Zotero.loadTranslator("search");
+		translate.setTranslator("b28d0d42-8549-4c6d-83fc-8382874a5cb9");
 	
-			var item = { itemType: "journalArticle", DOI: DOI };
-			translate.setSearch(item);
+		translate.setSearch({ itemType: "journalArticle", DOI: DOI });
 	
-			// don't save when item is done
-			translate.setHandler("itemDone", function (translate, item) {
-				selectArray[item.DOI] = item.title;
-				if (!item.title) {
-					Zotero.debug("No title available for " + item.DOI);
-					item.title = "[No Title]";
-					selectArray[item.DOI] = "[" + item.DOI + "]";
-				}
-				items[item.DOI] = item;
-			});
+		// don't save when item is done
+		translate.setHandler("itemDone", function (_translate, item) {
+			selectArray[item.DOI] = item.title;
+			if (!item.title) {
+				Zotero.debug("No title available for " + item.DOI);
+				item.title = "[No Title]";
+				selectArray[item.DOI] = "[" + item.DOI + "]";
+			}
+			items[item.DOI] = item;
+		});
 	
-			translate.setHandler("done", function (_translate) {
-				numDois--;
-				/*
-					DOI resolution runs async, but updates of numDois run on the main thread, so if we are here that means:
-					* I am done and have marked this
-					* All other async resolves do the same
-					* if numDois is zero (should not be < zero, but let's be careful out there), that means everyone is done
-				*/
-				if (numDois <= 0) {
-					completeDOIs(doc);
-				}
-			});
+		translate.setHandler("done", function () {
+			numDois--;
+			/*
+				DOI resolution runs async, but updates of numDois run on the main thread, so if we are here that means:
+				* I am done and have marked this
+				* All other async resolves do the same
+				* if numDois is zero (should not be < zero, but let's be careful out there), that means everyone is done
+			*/
+			if (numDois <= 0) {
+				completeDOIs(doc);
+			}
+		});
 	
-			// Don't throw on error
-			translate.setHandler("error", function () {});
+		// Don't throw on error
+		translate.setHandler("error", function () {});
 	
-			translate.translate();
-		})(doc, DOI);
+		translate.translate();
 	}
 }
 

--- a/DOI.js
+++ b/DOI.js
@@ -143,12 +143,6 @@ function retrieveDOIs(dois, doc) {
 	
 		translate.setHandler("done", function () {
 			numDois--;
-			/*
-				DOI resolution runs async, but updates of numDois run on the main thread, so if we are here that means:
-				* I am done and have marked this
-				* All other async resolves do the same
-				* if numDois is zero (should not be < zero, but let's be careful out there), that means everyone is done
-			*/
 			if (numDois <= 0) {
 				completeDOIs(doc);
 			}

--- a/DOI.js
+++ b/DOI.js
@@ -36,6 +36,8 @@
 	***** END LICENSE BLOCK *****
 */
 
+/* eslint-disable no-loop-func */
+
 // The variables items and selectArray will be filled during the first
 // as well as the second retrieveDOIs function call and therefore they
 // are defined global.
@@ -102,14 +104,10 @@ function detectWeb(doc, url) {
 	return false;
 }
 
-function completeDOIs(doc) {
+function completeDOIs(_doc) {
 	// all DOIs retrieved now
 	// check to see if there is more than one DOI
-	var numDOIs = 0;
-	for (var DOI in selectArray) {
-		numDOIs++;
-		if (numDOIs == 2) break;
-	}
+	var numDOIs = Object.keys(selectArray).length;
 	if (numDOIs == 0) {
 		throw new Error("DOI Translator: could not find DOI");
 	}
@@ -158,7 +156,7 @@ function retrieveDOIs(dois, doc, providers) {
 				}
 			});
 	
-			translate.setHandler("done", function (translate) {
+			translate.setHandler("done", function (_translate) {
 				numDois--;
 				if (numDois <= 0) {
 					Z.debug("Done with " + provider.name + ". Remaining DOIs: " + remainingDOIs);

--- a/DOI.js
+++ b/DOI.js
@@ -59,21 +59,22 @@ function getDOIs(doc) {
 	// DOI should never end with a period or a comma (we hope)
 	// Description at: http://www.doi.org/handbook_2000/appendix_1.html#A1-4
 	const DOIre = /\b10\.[0-9]{4,}\/[^\s&"']*[^\s&"'.,]/g;
-	const DOIXPath = "//text()[contains(., '10.')][not(parent::script or parent::style)]";
 
 	var dois = [];
 
-	var node, m, DOI;
-	var results = doc.evaluate(DOIXPath, doc, null, XPathResult.ANY_TYPE, null);
-	while ((node = results.iterateNext())) {
+	var m, DOI;
+	var treeWalker = doc.createTreeWalker(doc.documentElement, 4, null, false);
+	var ignore = ['script', 'style'];
+	while (treeWalker.nextNode()) {
+		if (ignore.includes(treeWalker.currentNode.parentNode.tagName.toLowerCase())) continue;
 		// Z.debug(node.nodeValue)
 		DOIre.lastMatch = 0;
-		while ((m = DOIre.exec(node.nodeValue))) {
+		while ((m = DOIre.exec(treeWalker.currentNode.nodeValue))) {
 			DOI = m[0];
-			if (DOI.substr(-1) == ")" && !DOI.includes("(")) {
+			if (DOI.endsWith(")") && !DOI.includes("(")) {
 				DOI = DOI.substr(0, DOI.length - 1);
 			}
-			if (DOI.substr(-1) == "}" && !DOI.includes("{")) {
+			if (DOI.endsWith("}") && !DOI.includes("{")) {
 				DOI = DOI.substr(0, DOI.length - 1);
 			}
 			// only add new DOIs


### PR DESCRIPTION
treewalker is [substantially faster](https://jsperf.com/text-node-traversal) than xpath -- I thought it would just be an architectural cleanup, but in my totally subjective hey-this-feels-faster tests, it does seem to make an actual difference, especially on the last test.

Also: address linter reports.